### PR TITLE
Tarea Mystery Lab (Docker + uv) - rubo6

### DIFF
--- a/students/rubo6/python_env/labs/mystery/Dockerfile
+++ b/students/rubo6/python_env/labs/mystery/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+# Instala uv
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /app
+
+# Copiamos SOLO tu requirements.txt (de TU carpeta en labs/mystery)
+COPY students/rubo6/python_env/labs/mystery/requirements.txt /app/requirements.txt
+
+# Creamos venv con uv e instalamos lo declarado (si está vacío, sigue)
+RUN uv venv /opt/venv && . /opt/venv/bin/activate && \
+    ( [ -s /app/requirements.txt ] && uv pip install -r /app/requirements.txt || true)
+
+# Copiamos el código del profe SIN modificarlo
+COPY professor/python_env/labs/mystery /app/labs/mystery
+
+# Usar python del venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Ejecutar EXACTAMENTE esto (como pide el README)
+CMD ["python", "labs/mystery/main.py"]

--- a/students/rubo6/python_env/labs/mystery/HOWTO.md
+++ b/students/rubo6/python_env/labs/mystery/HOWTO.md
@@ -1,0 +1,9 @@
+# Mystery Lab (Docker + uv) – Reproducir
+1) Desde la raíz del repo:
+   docker build -t mystery-uv -f students/rubo6/python_env/labs/mystery/Dockerfile .
+2) Ejecutar:
+   docker run --rm mystery-uv
+   # Debe imprimir la tabla y "OK – entorno configurado correctamente." (exit code 0)
+3) Si aparece ImportError, añade el paquete a:
+   students/rubo6/python_env/labs/mystery/requirements.txt
+   y repite 1) y 2).

--- a/students/rubo6/python_env/labs/mystery/README.md
+++ b/students/rubo6/python_env/labs/mystery/README.md
@@ -1,0 +1,43 @@
+# Mystery Lab (Docker + uv)
+
+Este pequeño ejercicio no lista dependencias. Tu objetivo es (entrega por Pull Request desde tu carpeta de estudiante):
+
+1) Crear un contenedor que ejecute `python labs/mystery/main.py` correctamente.
+2) Descubrir e instalar las dependencias necesarias usando `uv` dentro del contenedor.
+3) Lograr que la ejecución termine con código 0 y muestre una tabla con un valor.
+
+Reglas del juego:
+- No se revelan nombres de paquetes ni versiones.
+- Usa prueba y error leyendo los `ImportError`/`ModuleNotFoundError`.
+- Mantén un `requirements.txt` con las dependencias que vayas descubriendo.
+
+Pistas mínimas:
+- El programa imprime con “estilo/colores” y hace una petición HTTP a un endpoint público.
+
+Sugerencia de ciclo :
+
+```bash
+# 1) primera build & run (probablemente fallará con ImportError)
+docker build -t mystery-uv .
+docker run --rm mystery-uv
+
+# 2) lee el error, agrega una dependencia a requirements.txt
+echo '<descubierta>' >> requirements.txt
+
+# 3) reconstruye y vuelve a correr
+docker build -t mystery-uv .
+docker run --rm mystery-uv
+# repite hasta ver "OK — entorno configurado correctamente."
+```
+
+Entrega: crea tu rama, confirma tus cambios dentro de `students/{tu_carpeta}/python_env/` y abre tu Pull Request.
+
+Happy debugging!
+
+---
+
+Referencia y entrega
+- Para repasar entornos, PATH, `venv`, `pip` y `uv`, vuelve a `professor/python_env/README.md` (o a tu copia en `students/{tu_carpeta}/python_env/`).
+- La entrega es por Pull Request desde tu carpeta de estudiante; sigue el flujo de Git/GitHub indicado en el README principal.
+
+

--- a/students/rubo6/python_env/labs/mystery/main.py
+++ b/students/rubo6/python_env/labs/mystery/main.py
@@ -1,0 +1,59 @@
+import os
+import sys
+
+
+def main() -> int:
+    # Objetivo del reto: que este programa imprima un mensaje "bonito" y termine con 0.
+    # Pistas mínimas: el código intenta usar librerías externas comunes, pero no se listan aquí.
+    # El alumnado debe descubrirlas según los errores que aparezcan en tiempo de ejecución.
+
+    # 1) Usa variables de entorno y una librería externa para dar color/estilo al texto.
+    # 2) Hace una petición HTTP simple (solo GET) para obtener un dato público.
+    # 3) Formatea una pequeña tabla en salida estándar.
+
+    # Nota: no importamos arriba para que los errores muestren claramente qué falta.
+    try:
+        # colores bonitos
+        from rich import print as rprint  # type: ignore
+        from rich.table import Table  # type: ignore
+    except Exception as exc:
+        sys.stderr.write("Falta una dependencia para salida formateada.\n")
+        raise
+
+    try:
+        # http cliente
+        import httpx  # type: ignore
+    except Exception:
+        sys.stderr.write("Falta una dependencia para hacer requests HTTP.\n")
+        raise
+
+    # Fuente de datos: un endpoint público muy simple
+    url = os.environ.get("MYSTERY_URL", "https://httpbin.org/uuid")
+
+    try:
+        resp = httpx.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        sys.stderr.write("No se pudo obtener/parsear el JSON del endpoint.\n")
+        raise
+
+    # Construir una tabla mínima
+    table = Table(title="Mystery App — Resultado")
+    table.add_column("Clave", style="cyan", no_wrap=True)
+    table.add_column("Valor", style="magenta")
+
+    # Muestra 1–2 campos si existen; el objetivo no es el contenido, sino que corra
+    for key in ("uuid",):
+        value = data.get(key, "<no disponible>") if isinstance(data, dict) else "<no dict>"
+        table.add_row(key, str(value))
+
+    rprint(table)
+    rprint("[green]OK[/green] — entorno configurado correctamente.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/students/rubo6/python_env/labs/mystery/requirements.txt
+++ b/students/rubo6/python_env/labs/mystery/requirements.txt
@@ -1,0 +1,3 @@
+rich
+requests
+httpx


### PR DESCRIPTION
Después de batallar con una rama mal nombrada, crear una nueva rama y hacer todo de nuevo. Luego hice el dockerfile para crear la imagen y después el contenedor que corriera el main.py Desgraciadamente lo hice fuera de la carpeta original xd. y despues hice: Reubicar Mystery a students/rubo6/python_env/labs/mystery y ajustar Dockerfile/HOWTO
En resumen:

- Ejecuta python professor/python_env/labs/mystery/main.py dentro de contenedor.
- Descubrí dependencias por ImportError:
   - rich (estilos/colores)
   - requests 
   - httpx (HTTP)
- Entrego en students/rubo6/python_env/labs/mystery/:
  - Dockerfile (usa uv y venv en /opt/venv)
  - requirements.txt (top-level, sin versiones)
  - HOWTO.md (pasos de reproducción)
Prueba local: tabla + “OK – entorno configurado correctamente.” (exit 0). Adjunto captura de pantalla del contenedor corriendo main.py:

<img width="952" height="467" alt="image" src="https://github.com/user-attachments/assets/9c0c6588-1951-4a6d-8904-1fb8a09a5c0e" />

captura de pantalla del flujo git:
<img width="952" height="784" alt="image" src="https://github.com/user-attachments/assets/79ab39b4-c174-4d73-a1fb-4da5029f3b39" />

Captura de las extensiones de VScode:
<img width="952" height="241" alt="image" src="https://github.com/user-attachments/assets/c9b45938-714a-4c66-bab4-0fcf0591b0aa" />

Captura del interprete:
<img width="952" height="379" alt="image" src="https://github.com/user-attachments/assets/25552da4-e9cc-4189-8037-63b2095eade5" />

Sobre la configuración del editor. no sé a qué se refiera pero con gusto si quiere lo podemos checar el lunes.

Profesor en el readme.md menciona una bitacora, espero que se refiera a esta descripción del pr porque si se refiere a otro .md like BITACORA.md dentro de mis archivos entregables ya valí xd